### PR TITLE
fix: game_console WASD and add missing funcion bot

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -282,8 +282,10 @@ function toggleChat()
     consoleToggleChat.isChecked = not consoleToggleChat.isChecked
     if consoleToggleChat.isChecked then
         consoleToggleChat:setText(tr('Chat Off'))
+        consoleToggleChat.isChecked = true
     else
         consoleToggleChat:setText(tr('Chat On'))
+        consoleToggleChat.isChecked = false
     end
 end
 
@@ -358,6 +360,8 @@ function switchChatOnCall()
             toggleChat()
         end
     end
+
+    updateChatMode()
 end
 
 function disableChatOnCall()
@@ -2022,4 +2026,9 @@ function onChannelEvent(channelId, name, type)
             addTabText(fmt:format(name), SpeakTypesSettings.channelOrange, tab)
         end
     end
+end
+
+-- bot funtion
+function isEnabledWASD()
+    return consoleToggleChat:isChecked()
 end


### PR DESCRIPTION
bug to fix:

There is an error "in my opinion serious" because it is difficult to find.
There is a widget module that is "focused",
preventing the cursor from appearing when starting to write.

![image](https://github.com/Nottinghster/otclient/assets/114332266/441971b5-fa85-4f73-a07f-3745f9c4089f)


You have to click necessarily to write here.

![image](https://github.com/Nottinghster/otclient/assets/114332266/e2fa1e40-b6b1-43b3-bcf2-98fccf1e4a4c)
